### PR TITLE
Add class to `<details>` element

### DIFF
--- a/classes/Accordion.php
+++ b/classes/Accordion.php
@@ -24,7 +24,7 @@ class Accordion
   function theHTML($attributes, $content)
   {
     $open = ($attributes['openOnPageLoad'] === true) ? 'open' : '';
-    return '<details class="ucsc-content-blocks"' . $open . '>
+    return '<details class="ucsc-block-accordion"' . $open . '>
               <summary>' . $attributes['title'] . '</summary>'
               . $content .
            '</details>';

--- a/classes/Accordion.php
+++ b/classes/Accordion.php
@@ -24,7 +24,7 @@ class Accordion
   function theHTML($attributes, $content)
   {
     $open = ($attributes['openOnPageLoad'] === true) ? 'open' : '';
-    return '<details class="' . $attributes['className']  . '"' . $open . '>
+    return '<details class="ucsc-content-blocks"' . $open . '>
               <summary>' . $attributes['title'] . '</summary>'
               . $content .
            '</details>';


### PR DESCRIPTION
This PR adds a class to the `<details>` element on the Accordion block. This allows us to style it with the class rather than targeting the element, which we do now.