### PR TITLE
Update "files" object in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,16 @@
     "plugin"
   ],
   "files": [
-    "*",
+    "!.gitignore",
+    "!.github",
+    "!package.json",
+    "!package-lock.json",
+    "src",
     "classes",
+    "templates",
+    "index.php",
     "build/index.js",
-    "build/index.asset.php",
-    "templates"
+    "build/index.asset.php"
   ],
   "author": "UC Santa Cruz",
   "license": "ISC",


### PR DESCRIPTION
This commit/PR removes the `"*"` line of the files object in `package.json`. That catch-all allowed `.gitignore` files to be in the released plugin code, which conflicted with the CampusPress deployment workflow and caused the outage/error last week.

This commit/PR adds a more terse ruleset in the files object, which will prevent such issues in the future.

Tested locally using `npm run build` followed by `npm run plugin-zip`, then unpacking the zip file in a fresh instance of WordPress.