### PR TITLE
Allow site editors to use block wrapper attributes

### DIFF
--- a/classes/CourseCatalog.php
+++ b/classes/CourseCatalog.php
@@ -85,7 +85,8 @@ class CourseCatalog
     function theHTML($attributes) {
         ob_start();
         $courses = $this->getCachedCourses($attributes);
-        echo '<div id="courseCatalog">
+        $extraAttributes = get_block_wrapper_attributes(['id' => 'courseCatalog']);
+        echo '<div ' . $extraAttributes . '>
     <div class="introText">
         <label>
         Search Courses:<input type="text" id="search" onkeyup="tableSearch(event)">


### PR DESCRIPTION
This change allows site editors to set custom block wrapper attributes, which allows them to apply custom classes of their choosing to the block using Wordpress' standard interface. 