### PR TITLE
WPM-28: Add Help Text for LDAP API Key and LDAP CN

### DIFF
--- a/classes/SiteSettings.php
+++ b/classes/SiteSettings.php
@@ -370,13 +370,13 @@ class SiteSettings
   function ldapKeyHTML()
   { ?>
     <input type="text" name="ldap_api_key" value="<?php echo esc_attr(get_option('ldap_api_key')) ?>" />
-    <p>ex: LdApPaSsWoRd1!</p>
+    <p>ex: "your-ldap-password-here"</p>
   <?php }
 
   function ldapCN()
   { ?>
     <input type="text" name="ldap_cn" value="<?php echo esc_attr(get_option('ldap_cn')) ?>" />
-    <p>ex: pbsci-wordpress</p>
+    <p>ex: "pbsci-wordpress" (do not include cn=)</p>
   <?php }
 
   function ldapURL()


### PR DESCRIPTION
This PR adds some simple help text for the LDAP API Key and LDAP CN fields on the site settings page.