### PR TITLE
Editing cropped Campus Directory profile images

### DIFF
--- a/src/components/CampusDirectory/campusdirectory.css
+++ b/src/components/CampusDirectory/campusdirectory.css
@@ -147,7 +147,7 @@
 .section-header>a,
 .section-container.sub .section-header>a {
     font-size: inherit;
-    /* color: inherit; */
+    color: inherit;
     padding: 0;
     border: 0;
 }

--- a/src/components/CampusDirectory/campusdirectory.css
+++ b/src/components/CampusDirectory/campusdirectory.css
@@ -147,7 +147,7 @@
 .section-header>a,
 .section-container.sub .section-header>a {
     font-size: inherit;
-    color: inherit;
+    /* color: inherit; */
     padding: 0;
     border: 0;
 }
@@ -331,6 +331,8 @@ div.item-expertise>ul li {
     height: 160px;
     overflow: hidden;
     border-radius: 5px;
+    object-fit: cover;
+    object-position: top;
 }
 
 .tiled-page {

--- a/templates/CampusDirectoryTemplate.php
+++ b/templates/CampusDirectoryTemplate.php
@@ -147,7 +147,7 @@ $individualPageUrl = $items['nodeContent']['linkOutToCampusDirectory'] ?
                       $imgSrc = "//static.ucsc.edu/images/icon-slug.jpg";
                     }
                     if ($items['linkToProfile']) echo '<a class="u-url square-img" href="' . $individualPageUrl . $people[$i]['uid'][0] . '">';
-                    echo "<img src='" . $imgSrc . "' class='item-image square-img imgLiquid imgLiquid_bgSize imgLiquid_ready' style='object-fit: cover;'  alt='Profile picture of ". $people[$i]['cn'][0] ."' />";                  if ($items['linkToProfile']) echo '</a>';
+                    echo "<img src='" . $imgSrc . "' class='item-image square-img imgLiquid imgLiquid_bgSize imgLiquid_ready' alt='Profile picture of ". $people[$i]['cn'][0] ."' />";                  if ($items['linkToProfile']) echo '</a>';
                   }
                 ?>
               </div>


### PR DESCRIPTION
Two small changes:

- Adding CSS property that aligns profile images to "top", matching the appearance of photos on the Campus Directory website
- Moving an inline style in the template to the accompanying stylesheet

Example showing how [Weixin Cheng's](https://wp-dev.ucsc/?directoryprofilecruzid=wxcheng) profile appears in the Campus Directory and in the UCSC theme after the changes:

<img width="359" height="180" alt="Screenshot 2025-09-29 at 3 20 13 PM" src="https://github.com/user-attachments/assets/050a61f3-ae42-4df2-9dd3-ef206044b3a9" />
<img width="202" height="471" alt="Screenshot 2025-09-29 at 3 20 06 PM" src="https://github.com/user-attachments/assets/0ec7b033-f4b0-4090-be74-8af5c836f333" />
