### PR TITLE
WPM-18: Use ucscPersonIsPostDoc Attribute

### DIFF
--- a/classes/CampusDirectoryAPI.php
+++ b/classes/CampusDirectoryAPI.php
@@ -264,7 +264,8 @@ class CampusDirectoryAPI {
       if ($staffTypes['Regular Staff']) {
         foreach ($this->allStaffTypes as $type) {
           if (!$this->nodeContent['objStaffTypes'][$type]) {
-            $typeList .= "(ucscpersonpubstafftype=$type)";
+            if($type == 'Postdoctoral Scholar') $typeList .= "(ucscPersonIsPostDoc=TRUE)";
+            else $typeList .= "(ucscpersonpubstafftype=$type)";
             $typeCount++;
           }
         }
@@ -273,7 +274,8 @@ class CampusDirectoryAPI {
       } else {
         foreach ($this->allStaffTypes as $type) {
           if ($this->nodeContent['objStaffTypes'][$type]) { // we already know "Regular Staff" is false
-            $typeList .= "(ucscpersonpubstafftype=$type)";
+            if($type == 'Postdoctoral Scholar') $typeList .= "(ucscPersonIsPostDoc=TRUE)";
+            else $typeList .= "(ucscpersonpubstafftype=$type)";
             $typeCount++;
           }
         }


### PR DESCRIPTION
This PR updates the staff filtering logic to use the ucscPersonIsPostDoc attribute when filtering on or filtering out "Postdoctoral Scholar" type profiles. 