### PR TITLE
WPM-36: fix: update HTML structure to use div instead of label

### DIFF
--- a/classes/CourseCatalog.php
+++ b/classes/CourseCatalog.php
@@ -93,11 +93,11 @@ class CourseCatalog
         </label>
     </div>
     <div class="introText clickText">
-        <label>
+        <div>
             Select a course title for details.
             <a id="expandAll" class="expandAll collapseExpandLinks pointer">Expand all</a>
             <a id="collapseAll" class="collapseAll collapseExpandLinks pointer">Collapse all</a>
-        </label>
+        </div>
     </div>';
         echo '<table class="table-sortable" id="tableSorter">';
         echo '<thead><tr><th>Course #</th><th>Course Title</th><th>Course Level</th><th>Units</th></tr></thead>';


### PR DESCRIPTION
Jira Ticket: [WPM-36](https://ucsc-its.atlassian.net/browse/WPM-36)

Replaced 1 orphaned `<label>` tag with `<div>` tag to fix WCAG Level A 3.3.2 violation on course catalog page.

The labels were not associated with any form controls, which violated WCAG 3.3.2 and confused screen readers by implying non-existent input fields.