### PR TITLE
WPM-39: Fixed empty link issue by adding a line that checks if the user has an email before outputting an empty link.

### DIFF
--- a/templates/DirectoryProfileTemplate.php
+++ b/templates/DirectoryProfileTemplate.php
@@ -87,7 +87,9 @@ if (count($profileData)) {
                     <svg class="svg-inline--fa fa-envelope fa-w-16" title="User" aria-labelledby="svg-inline--fa-title-4" data-prefix="fas" data-icon="envelope" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><title id="svg-inline--fa-title-4">User</title><path fill="currentColor" d="M502.3 190.8c3.9-3.1 9.7-.2 9.7 4.7V400c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V195.6c0-5 5.7-7.8 9.7-4.7 22.4 17.4 52.1 39.5 154.1 113.6 21.1 15.4 56.7 47.8 92.2 47.6 35.7.3 72-32.8 92.3-47.6 102-74.1 131.6-96.3 154-113.7zM256 320c23.2.4 56.6-29.2 73.4-41.4 132.7-96.3 142.8-104.7 173.4-128.7 5.8-4.5 9.2-11.5 9.2-18.9v-19c0-26.5-21.5-48-48-48H48C21.5 64 0 85.5 0 112v19c0 7.4 3.4 14.3 9.2 18.9 30.6 23.9 40.7 32.4 173.4 128.7 16.8 12.2 50.2 41.8 73.4 41.4z"></path></svg>
                     <?php
                         for($i=0; $profileData["mail"] && $i<count($profileData["mail"]); $i++) {
-                            echo "<a href=\"mailto:{$profileData['mail'][$i]}\">{$profileData['mail'][$i]}</a>";
+                            if (!empty($profileData['mail'][$i])) {
+                                echo "<a href=\"mailto:{$profileData['mail'][$i]}\">{$profileData['mail'][$i]}</a>";
+                            }
                         }
                     ?>
                 </p>


### PR DESCRIPTION
[WPM-39](https://ucsc-its.atlassian.net/jira/software/projects/WPM/boards/205?selectedIssue=WPM-39)

Fixed an issue with empty links showing up on the front end when users would click on specific profiles on the campus directory block. Edited a line in DirectoryProfileTemplate.php (line 90) that checks if there is a valid email before outputting a link.

<img width="720" height="475" alt="Screenshot 2026-02-17 at 5 56 42 PM" src="https://github.com/user-attachments/assets/43cfcb95-c161-424f-964b-229d89b439a9" />

<img width="1199" height="590" alt="Screenshot 2026-02-17 at 5 57 08 PM" src="https://github.com/user-attachments/assets/a344b112-a2c1-48a9-9539-60cbcc227c16" />