### PR TITLE
Class schedule fix col width and flush rewrite rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+* Start the WordPress server environment
+  * `docker compose up -d`
+OR
+* Start the WordPress server environment AND the Node development environments for the theme and blocks plugin
+  * `docker compose -f docker-compose.yml -f docker-compose-start.yml up -d`
+
+
 ## About The Plugin
 
 This is a plugin that contains multiple custom gutenberg blocks.
@@ -50,6 +57,15 @@ npm install
 ```
 npm run start
 ```
+
+## Running the Docker services for development
+
+Now that WordPress is installed and the plugins and theme are built, we can start watching for changes to code and rebuild when necessary
+* Start the WordPress server environment
+  * `docker compose up -d`
+OR
+* Start the WordPress server environment AND the Node development environments for the theme and blocks plugin
+  * `docker compose -f docker-compose.yml -f docker-compose-start.yml up -d`
 
 ### Basic Block Development
 

--- a/classes/ClassSchedule.php
+++ b/classes/ClassSchedule.php
@@ -100,7 +100,6 @@ class ClassSchedule
       filemtime(plugin_dir_path(__FILE__) . $js_file),
       true
     );
-    wp_enqueue_script('classschedule-js');
 
     $css_file = '../src/components/ClassSchedule/classschedule.css';
     wp_register_style(
@@ -109,7 +108,6 @@ class ClassSchedule
       array(),
       filemtime(plugin_dir_path(__FILE__) . $css_file)
     );
-    wp_enqueue_style('classschedule');
   }
 
   function adminAssets()
@@ -213,6 +211,10 @@ class ClassSchedule
     usort($courses, function ($a, $b) {
       return (int) $a['catalog_nbr'] - (int) $b['catalog_nbr'];
     });
+
+    // Only enqueue JS/CSS when the block is actually rendered on the page
+    wp_enqueue_script('classschedule-js');
+    wp_enqueue_style('classschedule');
 
     ob_start();
     include(plugin_dir_path(__FILE__) . '../templates/ClassScheduleTemplate.php');

--- a/index.php
+++ b/index.php
@@ -41,8 +41,20 @@ function ucsc_gutenberg_blocks_activate() {
 
 function ucsc_gutenberg_blocks_deactivate() {
   flush_rewrite_rules();
+  delete_option('ucsc_gutenberg_blocks_rwflush');
 }
 
+// Auto-flush rewrite rules once after any deploy that modifies plugin files.
+// This prevents 404s on /directory/<cruzid>/ and /course/<term>/<id>/ routes
+// without requiring manual permalink saves or plugin reactivation.
+add_action('init', 'ucsc_gutenberg_blocks_maybe_flush_rewrites', 20);
+function ucsc_gutenberg_blocks_maybe_flush_rewrites() {
+  $file_mod = (string) filemtime(__FILE__);
+  if (get_option('ucsc_gutenberg_blocks_rwflush') !== $file_mod) {
+    flush_rewrite_rules();
+    update_option('ucsc_gutenberg_blocks_rwflush', $file_mod, true);
+  }
+}
 
 add_action('admin_enqueue_scripts', 'registerJSBuild');
 

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
  * Plugin Name: UCSC Gutenberg Blocks
  * Plugin URI: https://github.com/ucsc/ucsc-gutenberg-blocks
  * Description: Custom UCSC Gutenberg Blocks.
- * Version: 1.1.33
+ * Version: 1.1.34
  * Author: UC Santa Cruz
  * Author URI: https://github.com/ucsc
  */

--- a/src/blocks/ClassSchedule.js
+++ b/src/blocks/ClassSchedule.js
@@ -82,7 +82,7 @@ const ClassSchedule = () => {
                 setAttributes={setAttributes}
                 disabled={subjectOrDept !== "subject"}
               />
-              <small style={{ display: 'block', marginTop: '3em', fontSize: '0.7em', color: '#666' }}>version 1.1.33</small>
+              <small style={{ display: 'block', marginTop: '3em', fontSize: '0.7em', color: '#666' }}>version 1.1.34</small>
             </PanelBody>
           </Panel>
         </>

--- a/src/components/ClassSchedule/classschedule.css
+++ b/src/components/ClassSchedule/classschedule.css
@@ -336,7 +336,20 @@ a.cancelled {
 .el-table__header-row,
 .el-table__row {
   display: grid;
-  grid-template-columns: 40px 120px 1fr 150px 80px 170px 180px 160px 90px 100px;
+  /* Column mins mirror the old Vue/Element UI app (resources/js/pages/courses.vue).
+     We use fr units so leftover width is shared across visible columns,
+     which keeps Title→Seats spacing similar to the old table behavior. */
+  grid-template-columns:
+    45px
+    minmax(108px, 1.35fr)
+    minmax(175px, 2.19fr)
+    minmax(145px, 1.81fr)
+    minmax(80px,  1fr)
+    minmax(150px, 1.88fr)
+    minmax(140px, 1.75fr)
+    minmax(120px, 1.50fr)
+    minmax(90px,  1.13fr)
+    minmax(120px, 1.50fr);
   align-items: center;
 }
 

--- a/src/components/ClassSchedule/classschedule.js
+++ b/src/components/ClassSchedule/classschedule.js
@@ -257,16 +257,18 @@ function applyColumnVisibility() {
 // Rebuild CSS Grid column tracks based on which columns are visible.
 // Hidden columns get 0px tracks so the grid collapses them properly.
 var gridColumnDefs = [
-    { cls: 'col-status',     width: '40px' },
-    { cls: 'col-course-id',  width: '120px' },
-    { cls: 'col-title',      width: '1fr' },
-    { cls: 'col-seats',      width: '150px' },
-    { cls: 'col-days',       width: '80px' },
-    { cls: 'col-time',       width: '170px' },
-    { cls: 'col-location',   width: '180px' },
-    { cls: 'col-instructor', width: '160px' },
-    { cls: 'col-class-num',  width: '90px' },
-    { cls: 'col-enrollment', width: '100px' }
+    // Column mins mirror the old Vue/Element UI app (resources/js/pages/courses.vue).
+    // Use fr units so extra width is distributed across visible columns.
+    { cls: 'col-status',     width: '45px' },
+    { cls: 'col-course-id',  width: 'minmax(108px, 1.35fr)' },
+    { cls: 'col-title',      width: 'minmax(175px, 2.19fr)' },
+    { cls: 'col-seats',      width: 'minmax(145px, 1.81fr)' },
+    { cls: 'col-days',       width: 'minmax(80px, 1fr)' },
+    { cls: 'col-time',       width: 'minmax(150px, 1.88fr)' },
+    { cls: 'col-location',   width: 'minmax(140px, 1.75fr)' },
+    { cls: 'col-instructor', width: 'minmax(120px, 1.50fr)' },
+    { cls: 'col-class-num',  width: 'minmax(90px, 1.13fr)' },
+    { cls: 'col-enrollment', width: 'minmax(120px, 1.50fr)' }
 ];
 
 function updateGridTemplate() {

--- a/src/components/ClassSchedule/classschedule.js
+++ b/src/components/ClassSchedule/classschedule.js
@@ -216,6 +216,8 @@ function applyFilters() {
         savedStatusStates[f.dataset.status] = f.checked;
     });
 
+    saveColumnState();
+
     document.getElementById('filterModal').classList.remove('active');
 
     // A11Y: remove focus trap handler and restore focus to opener
@@ -228,6 +230,29 @@ function applyFilters() {
 
 // Default checked columns (matches the original Vue app defaults)
 const defaultColumns = ['seats', 'days'];
+
+// Persist column visibility choices in sessionStorage so they survive
+// navigation (e.g. clicking an instructor link and pressing Back).
+function saveColumnState() {
+    var state = {};
+    document.querySelectorAll('.column-toggle').forEach(function(t) {
+        state[t.dataset.column] = t.checked;
+    });
+    try { sessionStorage.setItem('cs_columns', JSON.stringify(state)); } catch(e) { /* ignore */ }
+}
+
+function restoreColumnState() {
+    try {
+        var saved = sessionStorage.getItem('cs_columns');
+        if (!saved) return;
+        var state = JSON.parse(saved);
+        document.querySelectorAll('.column-toggle').forEach(function(t) {
+            if (state.hasOwnProperty(t.dataset.column)) {
+                t.checked = state[t.dataset.column];
+            }
+        });
+    } catch(e) { /* ignore */ }
+}
 
 function applyColumnVisibility() {
     const table = document.getElementById('classScheduleTable');
@@ -314,6 +339,8 @@ function resetFilters() {
 
     const searchInput = document.getElementById('courseSearch');
     if (searchInput) searchInput.value = '';
+
+    try { sessionStorage.removeItem('cs_columns'); } catch(e) { /* ignore */ }
 }
 
 // Close modal when clicking the backdrop
@@ -437,8 +464,9 @@ function classScheduleChangeTerm(select) {
 
 // ── Init ──────────────────────────────────────────────────────────────────────
 
-// Apply default column visibility (time/location/instructor are unchecked by default)
+// Apply column visibility — restore any saved choices, then apply
 document.addEventListener('DOMContentLoaded', function() {
+    restoreColumnState();
     applyColumnVisibility();
 
     // a11y: attach change listener here instead of inline onchange to avoid jump menu a11y warning
@@ -447,6 +475,15 @@ document.addEventListener('DOMContentLoaded', function() {
         quarterDropdown.addEventListener('change', function() {
             classScheduleChangeTerm(this);
         });
+    }
+});
+
+// Re-apply column visibility on back/forward navigation.
+// Browsers restore checkbox state *after* DOMContentLoaded, so columns can
+// get out of sync with the checkboxes when the user navigates back.
+window.addEventListener('pageshow', function(event) {
+    if (event.persisted) {
+        applyColumnVisibility();
     }
 });
 

--- a/templates/CampusDirectoryTemplate.php
+++ b/templates/CampusDirectoryTemplate.php
@@ -51,19 +51,16 @@ $individualPageUrl = $items['nodeContent']['linkOutToCampusDirectory'] ?
                     echo '</td>';
                     foreach($items['informationToDisplay'] as $disItem) {
                       foreach($disItem as $key => $value) {
-                        if ($value == "Email") continue;
-                        $cellValue = (array_key_exists($key, $people[$i]) && !empty($people[$i][$key][0])) ? $people[$i][$key][0] : '';
                         echo '<td class="item-info table-renderer">';
-                          if ($cellValue) {
-                            echo '<strong>' . esc_html($cellValue) . '</strong>';
-                            echo '<ul class="inline-list">';
-                              if ($value == "Campus Email" || $value == "Other Email") {
-                                echo '<li><a href="mailto:' . esc_attr($cellValue) . '">' . esc_html($cellValue) . '</a></li>';
-                              } else {
-                                echo '<li>' . esc_html($cellValue) . '</li>';
-                              }
-                            echo '</ul>';
-                          }
+                          echo '<strong>' . $people[$i][$key][0] . '</strong>';
+                          echo '<ul class="inline-list">';
+                            if ($value == "Campus Email" || $value == "Other Email") {
+                              echo '<li><a href="mailto:' . $people[$i][$key][0] . '">' . $people[$i][$key][0] . '</a></li>';
+                            } else {
+                              if ($value == "Email") continue;
+                              echo '<li>' . $people[$i][$key][0] . '</li>';
+                            }
+                          echo '</ul>';
                         echo '</td>';
                       }
                     }
@@ -90,7 +87,7 @@ $individualPageUrl = $items['nodeContent']['linkOutToCampusDirectory'] ?
               ?>
               <div class="section-item h-card wrap">
                 <div class="item-body">
-                  <h2 class="h3-style item-name">
+                  <h3 class="item-name">
                     <?php
                       if ($items['linkToProfile']) {
                         echo '<a class="u-url" href="' . $individualPageUrl . $people[$i]['uid'][0] . '">';
@@ -100,7 +97,7 @@ $individualPageUrl = $items['nodeContent']['linkOutToCampusDirectory'] ?
                         echo '</a>';
                       }
                     ?>
-                  </h2>
+                  </h3>
                   <ul class="item-info list-renderer">
                     <?php
                       foreach($items['informationToDisplay'] as $disItem) {
@@ -150,8 +147,7 @@ $individualPageUrl = $items['nodeContent']['linkOutToCampusDirectory'] ?
                       $imgSrc = "//static.ucsc.edu/images/icon-slug.jpg";
                     }
                     if ($items['linkToProfile']) echo '<a class="u-url square-img" href="' . $individualPageUrl . $people[$i]['uid'][0] . '">';
-                    echo "<img src='" . esc_url($imgSrc) . "' class='item-image square-img imgLiquid imgLiquid_bgSize imgLiquid_ready' style='object-fit: cover;' alt='Profile picture of " . esc_attr($people[$i]['cn'][0]) . "' />";
-                    if ($items['linkToProfile']) echo '</a>';
+                    echo "<img src='" . $imgSrc . "' class='item-image square-img imgLiquid imgLiquid_bgSize imgLiquid_ready' alt='Profile picture of ". $people[$i]['cn'][0] ."' />";                  if ($items['linkToProfile']) echo '</a>';
                   }
                 ?>
               </div>


### PR DESCRIPTION
When moving from HTML tables in wcsi to div's now, some of the column widths were not preserved. These are fixed with this PR. Tracked in WPM-86

When rewrite rules change, it required either the plugin to be de-activated and activated or Settings > Permalinks in WP Admin and click Save Changes (without changing anything). With this PR we eliminate the need to do either of those by flushing rewrite rules once after any deploy that modifies plugin files so we don't get 404's when we click on class detail or instructor detail. Tracked in WPM-35 & WPM-87

