### PR TITLE
WPM-87 Fix broken profile photos in Campus Directory block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,33 @@
-* Start the WordPress server environment
-  * `docker compose up -d`
-OR
-* Start the WordPress server environment AND the Node development environments for the theme and blocks plugin
-  * `docker compose -f docker-compose.yml -f docker-compose-start.yml up -d`
-
 
 ## About The Plugin
+A WordPress plugin providing UCSC custom Gutenberg blocks: class schedule, course catalog, and campus directory as seen at:
+- https://history.ucsc.edu/courses/?sub=HIS
+- https://literature.ucsc.edu/class-schedule/course-catalog/
+- https://campusdirectory.ucsc.edu/cd_department?ou=soe
 
-This is a plugin that contains multiple UCSC custom gutenberg blocks: class schedule, course detail & campus directory.
+### Development Setup Instructions
+- Follow the setup instructions in the [wp-dev.ucsc README](https://github.com/ucsc/wp-dev.ucsc)
 
-## Getting Started
-
-The following will cover preqrequisites, development environment setup, basic block development and how to contribute.
-
-### Instructions
-
-- First create a Docker account here: https://app.docker.com/signup. Then download, install and start Docker: https://www.docker.com/products/docker-desktop/
-- Make sure you have git install on your system. In order to check if you have git installed use git --version in your terminal. If you do not have git installed follow this link: https://git-scm.com/install/
-- Then head to this repo and follow the readme: https://github.com/ucsc/wp-dev.ucsc
-  - After following the instructions you will have a local dev environment with ldap installed. It will also clone and build both the UCSC theme and plugin. Finally it will start the dev watchers that build the code every time you save a file while developing. Since all the build steps are mainly in docker, the only requirement is that you have docker and git.
-
-### Development Environment Setup
-
-- Create a multisite local site with localwp
-
-- In order for PHP Intelephense to work in VS Code open it with in the public directory.
-
-```
-cd ~/Local\ Sites/kumar-demo/app/public/
-```
-
-```
-code .
-```
-
-- In vscode's terminal clone this repo into the plugin directory
-
-```
-cd wp-content/plugins/
-```
-
-```
-git clone https://github.com/ucsc/ucsc-gutenberg-blocks.git
-```
-
-- Install and start wp-scripts
-
-```
-cd ucsc-gutenberg-blocks
-```
-
-```
-npm install
-```
-
-```
-npm run start
-```
-
-## Running the Docker services for development
-
-Now that WordPress is installed and the plugins and theme are built, we can start watching for changes to code and rebuild when necessary
-* Start the WordPress server environment
-  * `docker compose up -d`
-OR
-* Start the WordPress server environment AND the Node development environments for the theme and blocks plugin
-  * `docker compose -f docker-compose.yml -f docker-compose-start.yml up -d`
+### How To Contribute Code / Develop
+- From the wordpress root (by default wp-dev.ucsc): cd public/wp-content/plugins/ucsc-gutenberg-blocks
+- This is a separate repo that gets cloned to this directory during the initial setup `setup.sh`
+- Create Feature branch `git checkout -b "feature/WPM-xxx_my_feature"`
+- Write code, see [Anatomy of a Custom Block](CustomBlock.md)
+- Commit and push your changes, then create a PR into the `main` branch on GitHub
+- Instructions for pushing to the development and production campus press servers can be found https://docs.google.com/document/d/1XFb_JTMC8SP3HuwXVbqc6exMKpfMfYiO0XRE_QH8tjU/edit?tab=t.0#heading=h.pt501scbu4vi
 
 ### Basic Block Development
 
 As a reference a commit to adding a demo block to this repo can be found here: https://github.com/ucsc/ucsc-gutenberg-blocks/commit/10dafbecede6286ae2ad2868b58e61d90443dc08
 
-This commit show's how to create a Dynamic Block vs a Static block. There are many benefits to using Dynamic Blocks, here are some resources discussing the benefits:
+This commit shows how to create a Dynamic Block vs a Static Block. There are many benefits to using Dynamic Blocks, here are some resources discussing the benefits:
 
 - https://design.oit.ncsu.edu/2019/03/11/choosing-dynamic-blocks-one/
 - https://www.youtube.com/watch?v=0EtQO1kx8Vg
 
-#### Instructions:
 
+#### Instructions:
+```
 - Create a file in `src/classes` to hold the PHP/Wordpress code.
   - Actions can be added
   - Blocks can be registered
@@ -90,13 +40,25 @@ This commit show's how to create a Dynamic Block vs a Static block. There are ma
 - In `src/index.js` import your function and call it so that the block gets registered.
 - If needed, add JS and CSS component code under `src/components`
 
-### How To Contribute
+## VScode/Xdebug setup
+```
+The [PHP Debug plugin](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug) is required. On the debug tab click `Create a launch.json file` and select type `php`.
 
-- Create Feature branch `git checkout -b "feature/site-level-admin-form"`
-- Write code
-  - See [Anatomy of a Custom Block](CustomBlock.md)
-- Check `git diff` to see files that have been modified.
-- Git add the files you have modified or added: `git add <filename> <filename> <filename>` or use `git add .` if all the modified files need to be checked in
-- Commit with a good message `git commit -m "feat: ✨ Updating README"`
-- push code to github: `git push origin feature/site-level-admin-form`
-- In GitHub create a PR into the main branch
+You can replace the contents of `launch.json` with the following:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/var/www/html/wp-content/plugins/ucsc-gutenberg-blocks": "${workspaceRoot}"
+      },
+      "hostname": "wp-dev.ucsc"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OR
 
 ## About The Plugin
 
-This is a plugin that contains multiple custom gutenberg blocks.
+This is a plugin that contains multiple UCSC custom gutenberg blocks: class schedule, course detail & campus directory.
 
 ## Getting Started
 

--- a/classes/CampusDirectoryAPI.php
+++ b/classes/CampusDirectoryAPI.php
@@ -355,7 +355,11 @@ class CampusDirectoryAPI {
       ) {
         for ($attr = ldap_first_attribute($rli, $entry); $attr != false; $attr = ldap_next_attribute($rli, $entry)) {
           $attr = strtolower($attr);
-          $values = ldap_get_values($rli, $entry, $attr);
+          if ($attr === 'jpegphoto') {
+            $values = ldap_get_values_len($rli, $entry, $attr);
+          } else {
+            $values = ldap_get_values($rli, $entry, $attr);
+          }
           $person[$attr] = $values;
         }
         array_push($people, $person);

--- a/classes/CampusDirectoryAPI.php
+++ b/classes/CampusDirectoryAPI.php
@@ -355,6 +355,9 @@ class CampusDirectoryAPI {
       ) {
         for ($attr = ldap_first_attribute($rli, $entry); $attr != false; $attr = ldap_next_attribute($rli, $entry)) {
           $attr = strtolower($attr);
+          // WPM-87: jpegphoto is binary data and must be read with
+          // ldap_get_values_len() to avoid null-byte truncation that
+          // breaks base64 encoding and produces broken images.
           if ($attr === 'jpegphoto') {
             $values = ldap_get_values_len($rli, $entry, $attr);
           } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ucsc-gutenberg-blocks",
-  "version": "1.1.29",
+  "version": "1.1.34",
   "description": "Adds custom blocks to UCSC WordPress websites",
   "main": "test.js",
   "scripts": {

--- a/src/components/ClassSchedule/classschedule.css
+++ b/src/components/ClassSchedule/classschedule.css
@@ -93,12 +93,14 @@ a.cancelled {
 
 #courseSearch {
   flex: 1;
-  padding: 10px 10px;
+  padding: 10px 10px 10px 30px;
   font-size: 14px;
   border: none;
   outline: none;
   color: #666;
   min-width: 0;
+  background: transparent url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' fill='%23bbb'%3E%3Cpath d='M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z'/%3E%3C/svg%3E") no-repeat 8px center;
+  background-size: 14px 14px;
 }
 
 #courseSearch::placeholder {

--- a/src/components/ClassSchedule/classschedule.css
+++ b/src/components/ClassSchedule/classschedule.css
@@ -115,6 +115,7 @@ a.cancelled {
 .button-group {
   display: flex;
   gap: 0;
+  margin-left: auto;
 }
 
 .filter-button {

--- a/src/components/ClassSchedule/classschedule.css
+++ b/src/components/ClassSchedule/classschedule.css
@@ -62,7 +62,6 @@ a.cancelled {
 .input-with-select {
   display: flex;
   flex: 1;
-  max-width: 550px;
   border: 1px solid #dcdfe6;
   border-radius: 4px;
   overflow: hidden;

--- a/src/components/ClassSchedule/classschedule.js
+++ b/src/components/ClassSchedule/classschedule.js
@@ -39,14 +39,8 @@ function classScheduleSearch(event) {
     const activeStatuses = getActiveStatuses();
 
     rows.forEach(row => {
-        const cells = row.querySelectorAll('[role="cell"]');
-        let matchesSearch = false;
-
-        cells.forEach(cell => {
-            if (cell.textContent.toLowerCase().includes(searchTerm)) {
-                matchesSearch = true;
-            }
-        });
+        const titleCell = row.querySelector('.col-title');
+        const matchesSearch = titleCell && titleCell.textContent.toLowerCase().includes(searchTerm);
 
         const rowStatus = row.dataset.status;
         const matchesStatus = activeStatuses.length === 0 || activeStatuses.includes(rowStatus);
@@ -316,13 +310,8 @@ function applyStatusFilters() {
         const matchesStatus = activeStatuses.length === 0 || activeStatuses.includes(row.dataset.status);
 
         // Re-check search too so both filters stay in sync
-        const cells = row.querySelectorAll('[role="cell"]');
-        let matchesSearch = !searchTerm;
-        if (searchTerm) {
-            cells.forEach(cell => {
-                if (cell.textContent.toLowerCase().includes(searchTerm)) matchesSearch = true;
-            });
-        }
+        const titleCell = row.querySelector('.col-title');
+        const matchesSearch = !searchTerm || (titleCell && titleCell.textContent.toLowerCase().includes(searchTerm));
 
         row.style.display = (matchesStatus && matchesSearch) ? '' : 'none';
     });

--- a/templates/CampusDirectoryTemplate.php
+++ b/templates/CampusDirectoryTemplate.php
@@ -141,6 +141,8 @@ $individualPageUrl = $items['nodeContent']['linkOutToCampusDirectory'] ?
                 </div>
                 <?php
                   if ($displayPhoto) {
+                    // WPM-87: guard against empty photo data to avoid rendering
+                    // a broken data-URI <img> when no photo exists.
                     if (array_key_exists('jpegphoto', $people[$i]) && !empty($people[$i]['jpegphoto'][0])) {
                       $imgSrc = "data:image/jpeg;base64," . base64_encode($people[$i]['jpegphoto'][0]);
                     } else {

--- a/templates/CampusDirectoryTemplate.php
+++ b/templates/CampusDirectoryTemplate.php
@@ -141,8 +141,8 @@ $individualPageUrl = $items['nodeContent']['linkOutToCampusDirectory'] ?
                 </div>
                 <?php
                   if ($displayPhoto) {
-                    if (array_key_exists('jpegphoto', $people[$i])) {
-                      $imgSrc = "data:image/jpeg;base64, " .  base64_encode($people[$i]['jpegphoto'][0]);
+                    if (array_key_exists('jpegphoto', $people[$i]) && !empty($people[$i]['jpegphoto'][0])) {
+                      $imgSrc = "data:image/jpeg;base64," . base64_encode($people[$i]['jpegphoto'][0]);
                     } else {
                       $imgSrc = "//static.ucsc.edu/images/icon-slug.jpg";
                     }

--- a/templates/CourseDetailTemplate.php
+++ b/templates/CourseDetailTemplate.php
@@ -249,12 +249,13 @@ if ( ! empty( $secondary_sections ) ) {
 
 	<div class="has-global-padding is-layout-constrained wp-block-group alignwide">
 
-		<div class="course-status-heading">
-			<i class="<?php echo esc_attr( $status_class ); ?>" aria-hidden="true"></i>
-			<span><?php echo esc_html( $primary['enrl_status'] ); ?></span>
-		</div>
-
-		<h1 id="title" class="page-title"><span class="p-name"><?php echo esc_html( $primary['title_long'] ); ?></span></h1>
+		<h1 id="title" class="page-title">
+			<span class="course-status-heading">
+				<i class="<?php echo esc_attr( $status_class ); ?>" aria-hidden="true"></i>
+				<span><?php echo esc_html( $primary['enrl_status'] ); ?></span>
+			</span>
+			<span class="p-name"><?php echo esc_html( $primary['title_long'] ); ?></span>
+		</h1>
 
 		<div class="section-container person list-page">
 			<span><?php echo esc_html( $term_name ); ?></span> -
@@ -402,12 +403,13 @@ if ( ! empty( $secondary_sections ) ) {
 </main>
 
 <style>
-/* Keep status indicator aligned with the title at wide viewports.
-   !important overrides the theme's .is-layout-constrained > * { max-width: 80rem } */
+/* Status indicator on its own line above the title, inside the h1 to
+   avoid theme constrained-layout alignment issues */
 .course-status-heading {
-	max-width: none !important;
-	margin-left: 0 !important;
-	margin-right: 0 !important;
+	display: block;
+	font-size: 1rem;
+	font-weight: normal;
+	margin-bottom: 0.5em;
 }
 /* Secondary sections get a light-blue tinted background, matching old WCSI */
 .class-section {

--- a/templates/CourseDetailTemplate.php
+++ b/templates/CourseDetailTemplate.php
@@ -409,7 +409,19 @@ if ( ! empty( $secondary_sections ) ) {
 	display: block;
 	font-size: 1rem;
 	font-weight: normal;
-	margin-bottom: 0.75em;
+	margin-bottom: 0.25em;
+}
+/* Tighten spacing to match production WCSI layout */
+#title.page-title {
+	margin-bottom: 0.25em;
+}
+.section-container.person {
+	margin-top: 0;
+}
+#class-info .h3-style {
+	margin-top: 0.5em;
+	margin-bottom: 0.5em;
+	padding-top: 0;
 }
 /* Secondary sections get a light-blue tinted background, matching old WCSI */
 .class-section {

--- a/templates/CourseDetailTemplate.php
+++ b/templates/CourseDetailTemplate.php
@@ -249,8 +249,10 @@ if ( ! empty( $secondary_sections ) ) {
 
 	<div class="has-global-padding is-layout-constrained wp-block-group alignwide">
 
-		<i class="<?php echo esc_attr( $status_class ); ?>" aria-hidden="true"></i>
-		<span><?php echo esc_html( $primary['enrl_status'] ); ?></span>
+		<div class="course-status-heading">
+			<i class="<?php echo esc_attr( $status_class ); ?>" aria-hidden="true"></i>
+			<span><?php echo esc_html( $primary['enrl_status'] ); ?></span>
+		</div>
 
 		<h1 id="title" class="page-title"><span class="p-name"><?php echo esc_html( $primary['title_long'] ); ?></span></h1>
 

--- a/templates/CourseDetailTemplate.php
+++ b/templates/CourseDetailTemplate.php
@@ -402,9 +402,10 @@ if ( ! empty( $secondary_sections ) ) {
 </main>
 
 <style>
-/* Keep status indicator aligned with the title at wide viewports */
+/* Keep status indicator aligned with the title at wide viewports.
+   !important overrides the theme's .is-layout-constrained > * { max-width: 80rem } */
 .course-status-heading {
-	max-width: none;
+	max-width: none !important;
 }
 /* Secondary sections get a light-blue tinted background, matching old WCSI */
 .class-section {

--- a/templates/CourseDetailTemplate.php
+++ b/templates/CourseDetailTemplate.php
@@ -406,6 +406,8 @@ if ( ! empty( $secondary_sections ) ) {
    !important overrides the theme's .is-layout-constrained > * { max-width: 80rem } */
 .course-status-heading {
 	max-width: none !important;
+	margin-left: 0 !important;
+	margin-right: 0 !important;
 }
 /* Secondary sections get a light-blue tinted background, matching old WCSI */
 .class-section {

--- a/templates/CourseDetailTemplate.php
+++ b/templates/CourseDetailTemplate.php
@@ -409,7 +409,7 @@ if ( ! empty( $secondary_sections ) ) {
 	display: block;
 	font-size: 1rem;
 	font-weight: normal;
-	margin-bottom: 0.5em;
+	margin-bottom: 0.75em;
 }
 /* Secondary sections get a light-blue tinted background, matching old WCSI */
 .class-section {

--- a/templates/CourseDetailTemplate.php
+++ b/templates/CourseDetailTemplate.php
@@ -402,6 +402,10 @@ if ( ! empty( $secondary_sections ) ) {
 </main>
 
 <style>
+/* Keep status indicator aligned with the title at wide viewports */
+.course-status-heading {
+	max-width: none;
+}
 /* Secondary sections get a light-blue tinted background, matching old WCSI */
 .class-section {
 	margin: 10px 0;


### PR DESCRIPTION
- Use ldap_get_values_len() instead of ldap_get_values() for the jpegphoto LDAP attribute. ldap_get_values() is designed for text attributes and truncates at null bytes, which corrupts binary JPEG data and produces empty base64 strings on some PHP environments.
- Add !empty() guard on jpegphoto value so that if the photo data is missing or empty, the template falls back to the placeholder image instead of rendering a broken <img> tag.
- README update
