### PR TITLE
Dev/henryh/test ais course catalog changes

### DIFF
--- a/classes/CourseCatalog.php
+++ b/classes/CourseCatalog.php
@@ -2,6 +2,17 @@
 
 class CourseCatalog
 {
+    const PEOPLESOFT_TARGETS = array(
+        'prod' => array(
+            'host' => 'my.prd.ais.aws.ucsc.edu',
+            'to' => 'PSFT_CSPRD',
+        ),
+        'csqa' => array(
+            'host' => 'my.qa.ais.aws.ucsc.edu',
+            'to' => 'PSFT_CSQA',
+        ),
+    );
+
     function __construct() {
         add_action('init', array($this, 'renderFrontend'));
 
@@ -44,8 +55,136 @@ class CourseCatalog
         ));
     }
 
+    function normalizePeopleSoftTarget($target) {
+        $target = strtolower(trim((string) $target));
+        if ($target == 'qa' || $target == 'test') {
+            $target = 'csqa';
+        }
+
+        if (!array_key_exists($target, self::PEOPLESOFT_TARGETS)) {
+            $target = 'prod';
+        }
+
+        return $target;
+    }
+
+    function getRequestValue($names) {
+        foreach ($names as $name) {
+            if (isset($_GET[$name])) {
+                return is_array($_GET[$name]) ? '' : wp_unslash($_GET[$name]);
+            }
+        }
+
+        return null;
+    }
+
+    function getBooleanConfig($constantName, $envName, $default = false) {
+        $value = $default;
+        if (defined($constantName)) {
+            $value = constant($constantName);
+        } elseif (getenv($envName) !== false) {
+            $value = getenv($envName);
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    function isRequestOverrideAllowed() {
+        if (!is_user_logged_in() || !current_user_can('manage_options')) {
+            return false;
+        }
+
+        if ($this->getBooleanConfig('UCSC_COURSE_CATALOG_ALLOW_REQUEST_OVERRIDE', 'UCSC_COURSE_CATALOG_ALLOW_REQUEST_OVERRIDE')) {
+            return true;
+        }
+
+        $host = isset($_SERVER['HTTP_HOST']) ? strtolower($_SERVER['HTTP_HOST']) : '';
+        $allowedHosts = array(
+            'wp-dev.ucsc',
+            'wordpress-dev.ucsc.edu',
+            'localhost',
+            '127.0.0.1',
+        );
+
+        return in_array($host, $allowedHosts, true);
+    }
+
+    function getRequestTargetOverride() {
+        if (!$this->isRequestOverrideAllowed()) {
+            return null;
+        }
+
+        return $this->getRequestValue(array(
+            'ucsc_course_catalog_target',
+            'ucsc-course-catalog-target',
+        ));
+    }
+
+    function getPeopleSoftTarget() {
+        $target = 'prod';
+        if (defined('UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET')) {
+            $target = constant('UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET');
+        } elseif (getenv('UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET')) {
+            $target = getenv('UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET');
+        }
+
+        $requestTarget = $this->getRequestTargetOverride();
+        if ($requestTarget !== null && $requestTarget !== '') {
+            $target = $requestTarget;
+        }
+
+        $target = $this->normalizePeopleSoftTarget($target);
+        $config = self::PEOPLESOFT_TARGETS[$target];
+        $config['target'] = $target;
+        $config['url'] = 'https://' . $config['host'] . ':443/PSIGW/HttpListeningConnector';
+
+        return $config;
+    }
+
+    function shouldBypassCache() {
+        $bypassCache = $this->getBooleanConfig('UCSC_COURSE_CATALOG_BYPASS_CACHE', 'UCSC_COURSE_CATALOG_BYPASS_CACHE');
+        if ($this->isRequestOverrideAllowed()) {
+            $requestBypassCache = $this->getRequestValue(array(
+                'ucsc_course_catalog_bypass_cache',
+                'ucsc-course-catalog-bypass-cache',
+            ));
+            if ($requestBypassCache !== null) {
+                $bypassCache = filter_var($requestBypassCache, FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        return $bypassCache;
+    }
+
+    static function clearCachedCourses($target = 'all') {
+        global $wpdb;
+
+        $target = strtolower(trim($target));
+        if ($target == 'qa' || $target == 'test') {
+            $target = 'csqa';
+        }
+
+        if ($target && $target != 'all') {
+            $transientPrefix = 'course-catalog-' . $target . '-';
+        } else {
+            $transientPrefix = 'course-catalog-';
+        }
+
+        $transientLike = $wpdb->esc_like('_transient_' . $transientPrefix) . '%';
+        $timeoutLike = $wpdb->esc_like('_transient_timeout_' . $transientPrefix) . '%';
+
+        return $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+                $transientLike,
+                $timeoutLike
+            )
+        );
+    }
+
     // function getCachedCourses($subject, $subjectOrDept) {
     function getCachedCourses($attributes) {
+        $peopleSoftTarget = $this->getPeopleSoftTarget();
         $subjectOrDept = $attributes['subjectOrDept'];
         $queryStr = "";
         if ($subjectOrDept == 'dept') {
@@ -56,29 +195,63 @@ class CourseCatalog
             $lowerTitle = strtolower($attributes['subject']);
             $queryStr = '<subject>' . $lowerTitle . '</subject>';
         }
-        $body = get_transient('course-catalog-' . $lowerTitle . '-' . $subjectOrDept);
+        $cacheKey = 'course-catalog-' . $peopleSoftTarget['target'] . '-' . $lowerTitle . '-' . $subjectOrDept;
+        $body = $this->shouldBypassCache() ? false : get_transient($cacheKey);
         if (!$body) {
-            $request_body = '<!--?xml version="1.0"?-->
+            $request_body = '<?xml version="1.0"?>
       <catalog>
           ' . $queryStr . '
       </catalog>';
             $args = array(
                 'body' => $request_body,
                 'headers' => array(
-                    'Host' => 'my.prd.ais.aws.ucsc.edu',
+                    'Host' => $peopleSoftTarget['host'],
                     'Content-Type' => 'text/xml',
                     'OperationName' => 'SCX_SERVICE_CTLG.v1',
                     'From' => 'SCX_CTLG_TARGET',
-                    'To' => 'PSFT_CSPRD',
-                    'Connection' => 'close',
-                    'Cookie' => 'ROUTEID=.CSWEB1; AWSELB=37353D3D08AD73923AF46389C63E613E323FBAA9DFC82182E35FFF861EB914BAEF6182B6091A04D24D123FB954C7865F2D40E142E380F4B165EAB96D28B758CE5FC92F57B7; AWSELBCORS=37353D3D08AD73923AF46389C63E613E323FBAA9DFC82182E35FFF861EB914BAEF6182B6091A04D24D123FB954C7865F2D40E142E380F4B165EAB96D28B758CE5FC92F57B7'
+                    'To' => $peopleSoftTarget['to'],
+                    'Connection' => 'close'
                 ),
+                'timeout' => 30,
             );
-            $response = wp_remote_post("https://my.prd.ais.aws.ucsc.edu:443/PSIGW/HttpListeningConnector", $args);
+
+            $response = wp_remote_post($peopleSoftTarget['url'], $args);
+            if (is_wp_error($response)) {
+                return $response;
+            }
+
+            $response_code = wp_remote_retrieve_response_code($response);
             $body = wp_remote_retrieve_body($response);
-            set_transient('course-catalog-' . $lowerTitle . '-' . $subjectOrDept, $body, WEEK_IN_SECONDS);
+            if ($response_code < 200 || $response_code >= 300) {
+                return new WP_Error(
+                    'course_catalog_feed_error',
+                    'Course Catalog feed request failed.',
+                    array(
+                        'status' => $response_code,
+                        'target' => $peopleSoftTarget['target'],
+                    )
+                );
+            }
+
+            if (!$this->shouldBypassCache()) {
+                set_transient($cacheKey, $body, WEEK_IN_SECONDS);
+            }
         }
+
+        libxml_use_internal_errors(true);
         $xmlBody = simplexml_load_string($body);
+        if (!$xmlBody) {
+            libxml_clear_errors();
+            return new WP_Error(
+                'course_catalog_feed_xml_error',
+                'Course Catalog feed returned invalid XML.',
+                array(
+                    'target' => $peopleSoftTarget['target'],
+                )
+            );
+        }
+        libxml_clear_errors();
+
         return $xmlBody;
     }
 
@@ -87,6 +260,18 @@ class CourseCatalog
         $courses = $this->getCachedCourses($attributes);
         $extraAttributes = get_block_wrapper_attributes(['id' => 'courseCatalog']);
         echo '<div ' . $extraAttributes . '>
+    ';
+        if (is_wp_error($courses)) {
+            echo '<p class="introText">Course Catalog data is temporarily unavailable.</p>';
+            echo '</div>';
+
+            $output = ob_get_contents();
+            ob_end_clean();
+
+            return $output;
+        }
+
+        echo '
     <div class="introText">
         <label>
         Search Courses:<input type="text" id="search" onkeyup="tableSearch(event)">

--- a/classes/CourseCatalog.php
+++ b/classes/CourseCatalog.php
@@ -99,6 +99,7 @@ class CourseCatalog
         }
 
         $host = isset($_SERVER['HTTP_HOST']) ? strtolower($_SERVER['HTTP_HOST']) : '';
+        $host = preg_replace('/:\d+$/', '', $host);
         $allowedHosts = array(
             'wp-dev.ucsc',
             'wordpress-dev.ucsc.edu',

--- a/index.php
+++ b/index.php
@@ -73,6 +73,19 @@ function registerJSBuild() {
   wp_enqueue_script('ucscblocks', plugin_dir_url(__FILE__) . 'build/index.js', array('wp-blocks','wp-element', 'wp-components', 'wp-block-editor'), $script_version);
 }
 
+if (defined('WP_CLI') && WP_CLI) {
+  WP_CLI::add_command('ucsc course-catalog-cache clear', function($args, $assoc_args) {
+    $target = isset($assoc_args['target']) ? $assoc_args['target'] : 'all';
+    $deleted = CourseCatalog::clearCachedCourses($target);
+
+    WP_CLI::success(sprintf(
+      'Deleted %d Course Catalog transient row(s) for target "%s".',
+      $deleted,
+      $target
+    ));
+  });
+}
+
 
 
 

--- a/tests/php/CourseCatalogTest.php
+++ b/tests/php/CourseCatalogTest.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Dependency-free tests for CourseCatalog feed target and cache controls.
+ *
+ * Run from the plugin directory:
+ *   docker run --rm -v "$PWD:/plugin" -w /plugin php:8.1-cli \
+ *     php tests/php/CourseCatalogTest.php
+ */
+
+define( 'WEEK_IN_SECONDS', 604800 );
+
+$actions            = array();
+$current_user_id    = 0;
+$can_manage_options = false;
+$transients         = array();
+$remote_requests    = array();
+$remote_response    = array(
+	'code' => 200,
+	'body' => '<?xml version="1.0"?><catalog><course><subject>LIT</subject><catalog_nbr>1</catalog_nbr><title>Intro</title><level>Lower Division</level><units>5</units><description>Test</description></course></catalog>',
+);
+
+function add_action( $hook, $callback ) {
+	global $actions;
+	$actions[ $hook ] = $callback;
+}
+function wp_enqueue_script() {}
+function wp_register_script() {}
+function wp_enqueue_style() {}
+function wp_register_style() {}
+function plugins_url( $path ) {
+	return 'https://example.ucsc.edu/wp-content/plugins/ucsc-gutenberg-blocks/' . $path;
+}
+function plugin_dir_path( $file ) {
+	return dirname( $file ) . '/';
+}
+function filemtime( $file ) {
+	return 1;
+}
+function is_user_logged_in() {
+	global $current_user_id;
+	return 0 !== $current_user_id;
+}
+function current_user_can( $capability ) {
+	global $can_manage_options;
+	return 'manage_options' === $capability && $can_manage_options;
+}
+function wp_unslash( $value ) {
+	return stripslashes( $value );
+}
+function get_transient( $key ) {
+	global $transients;
+	return isset( $transients[ $key ] ) ? $transients[ $key ] : false;
+}
+function set_transient( $key, $value, $expiration ) {
+	global $transients;
+	$transients[ $key ] = array(
+		'value'      => $value,
+		'expiration' => $expiration,
+	);
+	return true;
+}
+function wp_remote_post( $url, $args ) {
+	global $remote_requests, $remote_response;
+	$remote_requests[] = array(
+		'url'  => $url,
+		'args' => $args,
+	);
+	return $remote_response;
+}
+function wp_remote_retrieve_response_code( $response ) {
+	return $response['code'];
+}
+function wp_remote_retrieve_body( $response ) {
+	return $response['body'];
+}
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+function get_block_wrapper_attributes( $attributes = array() ) {
+	return isset( $attributes['id'] ) ? 'id="' . $attributes['id'] . '"' : '';
+}
+
+class WP_Error {
+	private $code;
+	private $message;
+	private $data;
+
+	public function __construct( $code = '', $message = '', $data = array() ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	public function get_error_message() {
+		return $this->message;
+	}
+
+	public function get_error_data() {
+		return $this->data;
+	}
+}
+
+class Test_WPDB {
+	public $options = 'wp_options';
+	public $last_query;
+
+	public function esc_like( $text ) {
+		return addcslashes( $text, '_%\\' );
+	}
+
+	public function prepare( $query, ...$args ) {
+		foreach ( $args as $arg ) {
+			$query = preg_replace( '/%s/', "'" . $arg . "'", $query, 1 );
+		}
+		return $query;
+	}
+
+	public function query( $query ) {
+		$this->last_query = $query;
+		return 2;
+	}
+}
+
+$wpdb = new Test_WPDB();
+
+require __DIR__ . '/../../classes/CourseCatalog.php';
+
+$tests  = 0;
+$failed = 0;
+
+function check( $label, $condition ) {
+	global $tests, $failed;
+	$tests++;
+
+	if ( $condition ) {
+		echo "  PASS  $label\n";
+		return;
+	}
+
+	$failed++;
+	echo "  FAIL  $label\n";
+}
+
+function reset_test_state() {
+	global $current_user_id, $can_manage_options, $transients, $remote_requests, $remote_response, $wpdb;
+
+	$current_user_id    = 0;
+	$can_manage_options = false;
+	$transients         = array();
+	$remote_requests    = array();
+	$remote_response    = array(
+		'code' => 200,
+		'body' => '<?xml version="1.0"?><catalog><course><subject>LIT</subject><catalog_nbr>1</catalog_nbr><title>Intro</title><level>Lower Division</level><units>5</units><description>Test</description></course></catalog>',
+	);
+	$wpdb->last_query   = null;
+
+	$_GET    = array();
+	$_SERVER = array();
+
+	putenv( 'UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET' );
+	putenv( 'UCSC_COURSE_CATALOG_BYPASS_CACHE' );
+	putenv( 'UCSC_COURSE_CATALOG_ALLOW_REQUEST_OVERRIDE' );
+}
+
+function make_catalog() {
+	reset_test_state();
+	return new CourseCatalog();
+}
+
+echo "PeopleSoft target selection:\n";
+
+$catalog = make_catalog();
+$target  = $catalog->getPeopleSoftTarget();
+check( 'defaults to production target', 'prod' === $target['target'] );
+check( 'defaults to production Host header value', 'my.prd.ais.aws.ucsc.edu' === $target['host'] );
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET=qa' );
+$target = $catalog->getPeopleSoftTarget();
+check( 'maps qa env alias to csqa target', 'csqa' === $target['target'] );
+check( 'uses CSQA To header value', 'PSFT_CSQA' === $target['to'] );
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET=definitely-not-real' );
+$target = $catalog->getPeopleSoftTarget();
+check( 'falls back to production for unknown env target', 'prod' === $target['target'] );
+
+echo "request override gating:\n";
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET=csqa' );
+$_SERVER['HTTP_HOST']                 = 'wp-dev.ucsc:443';
+$_GET['ucsc_course_catalog_target']   = 'prod';
+$current_user_id                      = 1;
+$can_manage_options                   = true;
+$target                              = $catalog->getPeopleSoftTarget();
+check( 'admin can override target on dev host with port', 'prod' === $target['target'] );
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET=csqa' );
+$_SERVER['HTTP_HOST']                 = 'wordpress.ucsc.edu:443';
+$_GET['ucsc_course_catalog_target']   = 'prod';
+$current_user_id                      = 1;
+$can_manage_options                   = true;
+$target                              = $catalog->getPeopleSoftTarget();
+check( 'admin cannot override target on production host by default', 'csqa' === $target['target'] );
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET=csqa' );
+$_SERVER['HTTP_HOST']                 = 'localhost:8080';
+$_GET['ucsc_course_catalog_target']   = 'prod';
+$target                              = $catalog->getPeopleSoftTarget();
+check( 'logged-out request cannot override target on dev host', 'csqa' === $target['target'] );
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_PEOPLESOFT_TARGET=csqa' );
+putenv( 'UCSC_COURSE_CATALOG_ALLOW_REQUEST_OVERRIDE=true' );
+$_SERVER['HTTP_HOST']                 = 'wordpress.ucsc.edu';
+$_GET['ucsc_course_catalog_target']   = 'prod';
+$current_user_id                      = 1;
+$can_manage_options                   = true;
+$target                              = $catalog->getPeopleSoftTarget();
+check( 'explicit server opt-in allows production-host admin override', 'prod' === $target['target'] );
+
+echo "cache controls:\n";
+
+$catalog = make_catalog();
+check( 'cache bypass defaults off', false === $catalog->shouldBypassCache() );
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_BYPASS_CACHE=true' );
+check( 'env var enables cache bypass', true === $catalog->shouldBypassCache() );
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_BYPASS_CACHE=true' );
+$_SERVER['HTTP_HOST']                         = 'wp-dev.ucsc';
+$_GET['ucsc_course_catalog_bypass_cache']     = '0';
+$current_user_id                              = 1;
+$can_manage_options                           = true;
+check( 'admin request can disable cache bypass on dev host', false === $catalog->shouldBypassCache() );
+
+$catalog = make_catalog();
+$catalog->getCachedCourses(
+	array(
+		'subjectOrDept' => 'dept',
+		'department'    => 'lit',
+		'subject'       => '',
+	)
+);
+check( 'successful response is cached under target-aware key', isset( $transients['course-catalog-prod-lit-dept'] ) );
+check( 'successful response uses one remote request', 1 === count( $remote_requests ) );
+
+$catalog = make_catalog();
+putenv( 'UCSC_COURSE_CATALOG_BYPASS_CACHE=true' );
+$catalog->getCachedCourses(
+	array(
+		'subjectOrDept' => 'dept',
+		'department'    => 'lit',
+		'subject'       => '',
+	)
+);
+check( 'cache bypass does not store successful response', array() === $transients );
+check( 'cache bypass still calls the remote feed', 1 === count( $remote_requests ) );
+
+echo "cache clearing:\n";
+
+$deleted = CourseCatalog::clearCachedCourses( 'qa' );
+check( 'cache clear returns deleted row count', 2 === $deleted );
+check( 'cache clear maps qa alias to csqa transient prefix', false !== strpos( $wpdb->last_query, '_transient_course-catalog-csqa-' ) );
+
+$deleted = CourseCatalog::clearCachedCourses();
+check( 'cache clear all returns deleted row count', 2 === $deleted );
+check( 'cache clear all targets all course catalog transients', false !== strpos( $wpdb->last_query, '_transient_course-catalog-' ) );
+
+echo "\n" . ( $tests - $failed ) . "/$tests passed\n";
+exit( 0 === $failed ? 0 : 1 );


### PR DESCRIPTION
This PR allows a way to evaluate the stage AIS feed on our wordpress servers as well as bypass the cache. 
It uses GET arguments to operate in cache busting or stage AIS feed mode. quick hack to test with. Other ideas are welcome. I think we only need to evaluate the test server as it has the same outgoing IP as prod. so in theory we could just hardcode it.