### PR TITLE
WPM-101 — Course Catalog: Fix mobile layout

### DIFF
--- a/src/components/CourseCatalog/tablesorter.css
+++ b/src/components/CourseCatalog/tablesorter.css
@@ -105,3 +105,31 @@ span.secret {
     text-decoration: underline;
     cursor: pointer;
 }
+
+@media (max-width: 600px) {
+    #courseCatalog {
+        overflow-x: auto;
+    }
+
+    .table-sortable {
+        width: 100%;
+    }
+
+    .table-sortable thead th {
+        white-space: nowrap;
+    }
+
+    .table-sortable tbody tr.pointer td:first-child {
+        white-space: nowrap;
+    }
+
+    .introText {
+        height: auto;
+        min-height: 30px;
+    }
+
+    .collapseExpandLinks {
+        padding: 0 10px;
+        white-space: nowrap;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `@media (max-width: 600px)` block to `tablesorter.css` to fix the course catalog layout on mobile devices
- Makes the catalog table horizontally scrollable on small screens
- Prevents text wrapping in table headers and the first column to keep rows readable
- Fixes `.introText` height and `.collapseExpandLinks` padding for mobile viewports

## Jira
[WPM-101](https://ucsc-its.atlassian.net/browse/WPM-101)

## Test plan
- [ ] Open the Course Catalog block on a mobile viewport (≤ 600px)
- [ ] Verify the table scrolls horizontally and does not overflow the page
- [ ] Verify table headers and first-column text do not wrap
- [ ] Verify the intro text and collapse/expand links display correctly
- [ ] Verify no regressions on desktop viewports